### PR TITLE
LFLT-527 Add metadata caching for file retrieval

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -65,6 +65,9 @@ lsrs:
   # Logging settings
   logging:
 
+    # Minimum logging level (defaults to 'info' if not specified)
+    min-level: info
+
     #  Log exposure to TinyLogProcessor (TLP) service
     tlp-logging:
 

--- a/config/test.yml
+++ b/config/test.yml
@@ -26,6 +26,7 @@ lsrs:
     oauth-issuer: http://localhost:9999
     oauth-audience: test-lsrs-audience
   logging:
+    min-level: debug
     tlp-logging:
       enabled: false
       host: http://localhost:9999/tlp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-static-resource-server",
-  "version": "0.7.0-dev",
+  "version": "0.8.0-dev",
   "bin": "./dist/lsrs-main.js",
   "scripts": {
     "start": "ts-node ./src/lsrs-main.ts",

--- a/src/lsrs/core/config/configuration-provider.ts
+++ b/src/lsrs/core/config/configuration-provider.ts
@@ -1,4 +1,5 @@
 import config from "config";
+import {TLogLevelName} from "tslog";
 import {Service} from "typedi";
 import {FileInput, MIMEType} from "../model/file-input";
 
@@ -11,7 +12,7 @@ type StorageConfigKey = "upload-path" | "max-age-in-days" | "permission" | "acce
 type AuthConfigKey = "oauth-issuer" | "oauth-audience";
 type AcceptorConfigKey = "accepted-as" | "group-root-directory" | "accepted-mime-types";
 type AcceptorConfigNode = { [Key in AcceptorConfigKey]: string | string[] };
-type LoggingConfigKey = "tlp-logging";
+type LoggingConfigKey = "tlp-logging" | "min-level";
 type TLPLoggingConfigKey = "enabled" | "host";
 type ActuatorConfigKey = "appName" | "abbreviation";
 type ConfigKey = ServerConfigKey | DatasourceConfigKey | StorageConfigKey | AcceptorConfigKey | AuthConfigKey | LoggingConfigKey | TLPLoggingConfigKey | ActuatorConfigKey;
@@ -136,11 +137,13 @@ export class AuthConfig {
  */
 export class LoggingConfig {
 
+    readonly minLevel: TLogLevelName;
     readonly tlpLoggingEnabled: boolean;
     readonly tlpHost: string;
 
     constructor(parameters: MapNode) {
         const tlpLogging: MapNode = getValue(parameters, "tlp-logging");
+        this.minLevel = getValue(parameters, "min-level", "info");
         this.tlpLoggingEnabled = getValue(tlpLogging, "enabled", false);
         this.tlpHost = getValue(tlpLogging, "host");
     }

--- a/src/lsrs/helper/cache.ts
+++ b/src/lsrs/helper/cache.ts
@@ -1,0 +1,79 @@
+import {Logger} from "tslog";
+import {Service} from "typedi";
+import LoggerFactory from "./logger-factory";
+
+/**
+ * In-memory caching component.
+ * Uses a 2-level map, where the first level is the cache group (its name being the key) and the second level is
+ * storing arbitrary key-value pairs. Caches are automatically created upon first usage.
+ */
+@Service()
+export class InMemoryCache {
+
+    private readonly contents: Map<string, Map<any, any>> = new Map();
+    private readonly logger: Logger = LoggerFactory.getLogger(InMemoryCache);
+
+    /**
+     * Returns a stored value from the specified cache by its key. Also, able to calculate and immediately store (and
+     * return) the value in case it's missing, via the optional 'calculate' function.
+     *
+     * @param cacheName cache group name
+     * @param key key of the item
+     * @param calculate value calculation function for missing item
+     * @returns either the stored (or calculated and right away stored) value or undefined if the requested key is missing and no 'calculate' function is defined
+     */
+    get<Key, Value>(cacheName: string, key: Key, calculate?: (key: Key) => Value): Value | undefined {
+
+        this.ensureCache(cacheName);
+
+        if (!this.contents.get(cacheName)!.has(key)) {
+            this.logger.debug(`Cache miss for ${cacheName}/${key}`);
+            const calculatedValue = calculate?.(key);
+            if (calculatedValue) {
+                this.put(cacheName, key, calculatedValue);
+            }
+        } else {
+            this.logger.debug(`Cache hit for ${cacheName}/${key}`);
+        }
+
+        return this.contents.get(cacheName)!.get(key);
+    }
+
+    /**
+     * Stores a value in the specified cache under the given key.
+     *
+     * @param cacheName cache group name
+     * @param key key of the item (arbitrary type, string being recommended for the purpose)
+     * @param value value to be stored (arbitrary type)
+     */
+    put<Key, Value>(cacheName: string, key: Key, value: Value): void {
+
+        this.ensureCache(cacheName);
+
+        if (value) {
+            this.logger.debug(`Cache put for ${cacheName}/${key}`);
+            this.contents.get(cacheName)!.set(key, value);
+        } else {
+            this.logger.warn(`Rejecting putting empty value into ${cacheName}/${key}`);
+        }
+    }
+
+    /**
+     * Removes the identified value (by its) from the specified cache.
+     *
+     * @param cacheName cache group name
+     * @param key key of the item
+     */
+    remove<Key>(cacheName: string, key: Key): void {
+        this.contents.get(cacheName)?.delete(key);
+        this.logger.debug(`Cache invalidation for ${cacheName}/${key}`);
+    }
+
+    private ensureCache(cacheName: string): void {
+
+        if (!this.contents.has(cacheName)) {
+            this.contents.set(cacheName, new Map<any, any>());
+            this.logger.info(`Cache '${cacheName}' initialized`);
+        }
+    }
+}

--- a/src/lsrs/helper/logger-factory.ts
+++ b/src/lsrs/helper/logger-factory.ts
@@ -23,6 +23,7 @@ export default class LoggerFactory {
         if (!this.initialized) {
             this.initialized = true;
             this.tlpLogging = Container.get(ConfigurationProvider).getLoggingConfig();
+            this.config.minLevel = this.tlpLogging.minLevel;
         }
     }
 

--- a/src/lsrs/helper/tlp-transport.ts
+++ b/src/lsrs/helper/tlp-transport.ts
@@ -35,7 +35,7 @@ class TLPLogMessage {
     private readonly exception?: ErrorLog;
     
     /**
-     * This constructor extract and converts log entry data from a TSLog log entry object.
+     * This constructor extracts and converts log entry data from a TSLog log entry object.
      *
      * @param entry TSLog log entry object of type ILogObject
      */

--- a/test/lsrs/core/config/configuration-provider.test.ts
+++ b/test/lsrs/core/config/configuration-provider.test.ts
@@ -88,6 +88,7 @@ describe("Unit tests for ConfigurationProvider", () => {
 
             // then
             expect(result).not.toBeNull();
+            expect(result.minLevel).toBe("debug");
             expect(result.tlpLoggingEnabled).toBe(false);
             expect(result.tlpHost).toBe("http://localhost:9999/tlp");
         });

--- a/test/lsrs/helper/cache.test.ts
+++ b/test/lsrs/helper/cache.test.ts
@@ -1,0 +1,111 @@
+import {InMemoryCache} from "../../../src/lsrs/helper/cache";
+
+describe("Unit tests for InMemoryCache", () => {
+
+    let cache: InMemoryCache;
+
+    beforeEach(() => {
+        cache = new InMemoryCache();
+    });
+
+    describe("Test scenarios for #get", () => {
+
+        it("should return undefined value from empty cache", () => {
+
+            // when
+            const result = cache.get("empty-cache-1", "key1");
+
+            // then
+            expect(result).toBeUndefined();
+        });
+
+        it("should return calculated value from empty cache", () => {
+
+            // given
+            const expectedValue = "calculated-value-1";
+
+            // when
+            const result = cache.get("empty-cache-2", "key-calculated", (_) => expectedValue);
+
+            // then
+            expect(result).toBe(expectedValue);
+        });
+
+        it("should return stored value from populated cache", () => {
+
+            // given
+            cache.put("populated-cache-1", "key1", 123);
+            cache.put("populated-cache-1", "key2", 456);
+            cache.put("populated-cache-1", "key3", 789);
+
+            // when
+            const result = cache.get("populated-cache-1", "key2");
+
+            // then
+            expect(result).toBe(456);
+        });
+    });
+
+    describe("Test scenarios for #put", () => {
+
+        it("should store value in cache", () => {
+
+            // given
+            const cacheName = "new-cache-1";
+            const key = "key-new";
+            const valueToStore = "new-value-1";
+
+            expect(cache.get(cacheName, key)).toBeUndefined();
+
+            // when
+            cache.put(cacheName, key, valueToStore);
+
+            // then
+            expect(cache.get(cacheName, key)).toBe(valueToStore);
+        });
+
+        it("should reject storing null value in cache", () => {
+
+            // given
+            const cacheName = "new-cache-2";
+            const key = "key-new-2";
+
+            expect(cache.get(cacheName, key)).toBeUndefined();
+
+            // when
+            cache.put(cacheName, key, null);
+
+            // then
+            expect(cache.get(cacheName, key)).toBeUndefined();
+        });
+    });
+
+    describe("Test scenarios for #remove", () => {
+
+        it("should silently ignore deleting non-existing key", () => {
+
+            // when
+            cache.remove("empty-cache-3", "key-to-delete");
+
+            // then
+            // silent execution expected
+        });
+
+        it("should remove existing key", () => {
+
+            // given
+            const cacheName = "cache-to-invalidated";
+            const key = "key-to-delete-1";
+            const storedValue = "this-will-be-deleted";
+
+            cache.put(cacheName, key, storedValue);
+            expect(cache.get(cacheName, key)).toBe(storedValue);
+
+            // when
+            cache.remove(cacheName, key);
+
+            // then
+            expect(cache.get(cacheName, key)).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
 - Implemented simply in-memory cache
 - Integrated cache into download flow
 - Integrated cache invalidation in remove and update operations
 - Added minimum log level configuration parameter (was needed for debug-level cache logs)
 - Added/aligned unit tests
 - Bumped application version to 0.8.0-dev