### PR TITLE
LFLT-534 Files cannot be uploaded to LSRS via Jersey REST client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-static-resource-server",
-  "version": "0.8.2-dev",
+  "version": "0.8.3-dev",
   "bin": "./dist/lsrs-main.js",
   "scripts": {
     "start": "ts-node ./src/lsrs-main.ts",

--- a/src/lsrs/web/controller-registration.ts
+++ b/src/lsrs/web/controller-registration.ts
@@ -14,8 +14,8 @@ import {
     FileUploadRequestModel,
     UpdateFileMetadataRequestModel
 } from "./model/files";
+import {formidableUploadMiddleware} from "./utility/formidable-support";
 import {ParameterizedMappingHelper, ParameterlessMappingHelper} from "./utility/mapping-helper";
-import {formidableUploadMiddleware} from "./utility/middleware";
 
 /**
  * Component to handle controller registrations.

--- a/src/lsrs/web/utility/formidable-support.ts
+++ b/src/lsrs/web/utility/formidable-support.ts
@@ -1,0 +1,109 @@
+import {NextFunction, Request, Response} from "express";
+import formidable, {File, Part} from "formidable";
+import IncomingForm from "formidable/Formidable";
+import {Writable} from "stream";
+import {HttpStatus} from "../model/common";
+
+/**
+ * File upload handler middleware for Express using Formidable form parser.
+ * Parses the file upload form and collects the file chunks into a FileUploadWritable object. When parsing is done,
+ * the collected chunks are converted to a Buffer and finally the file contents and the metadata provided with the
+ * uploaded file are passed forward on the chain in the standard Express request object (under the original form field
+ * names, inputFile, subFolder and description). Any error that happening while parsing the form triggers a rejection,
+ * while success resolved the wrapping Promise object.
+ *
+ * @param request Express Request object
+ * @param response Express Response object
+ * @param next Express next function
+ */
+export const formidableUploadMiddleware = async (request: Request, response: Response, next: NextFunction) => {
+
+    await new Promise<void>((resolve, _) => {
+
+        const fileUploadWritable = new FileUploadWritable();
+        const form = formidable({
+            fileWriteStreamHandler: () => fileUploadWritable,
+        });
+
+        form.onPart = removeMIMETypeIfNeeded(form);
+
+        form.parse(request, (error, fields, files) => {
+
+            if (error) {
+                handleErrorResponse(response, error);
+            } else {
+                populateRequestBody(fields, files, request, fileUploadWritable);
+            }
+
+            resolve();
+        });
+    });
+
+    next();
+}
+
+/**
+ * Writable implementation for file uploads, collecting the received chunks into array, which can be converted into a buffer.
+ */
+class FileUploadWritable extends Writable {
+
+    private readonly chunks: any[] = [];
+
+    _write(chunk: any, encoding: BufferEncoding, callback: (error?: (Error | null)) => void) {
+        this.chunks.push(chunk);
+        callback();
+    }
+
+    /**
+     * Returns the collected chunks as concatenated buffer.
+     */
+    getBuffer(): Buffer {
+        return Buffer.concat(this.chunks);
+    }
+}
+
+/**
+ * The code below aims to mitigate a known issue with how Formidable is handling text/plain form-data fields.
+ * https://github.com/node-formidable/formidable/issues/875
+ *
+ * @param form Formidable IncomingForm object
+ */
+/* istanbul ignore next */
+function removeMIMETypeIfNeeded(form: IncomingForm) {
+
+    function isTextInputField(part: formidable.Part) {
+        // @ts-ignore
+        return part.mimetype && !part.headers["content-disposition"]?.match(/filename="/);
+    }
+
+    return (part: Part) => {
+
+        if (isTextInputField(part)) {
+            // @ts-ignore
+            delete part.mimetype;
+        }
+
+        form._handlePart(part);
+    };
+}
+
+function handleErrorResponse(response: Response, error: any) {
+
+    response
+        .status(HttpStatus.BAD_REQUEST)
+        .json({message: error.message ?? "Invalid input file"});
+}
+
+function populateRequestBody(fields: formidable.Fields, files: formidable.Files, request: Request, fileUploadWritable: FileUploadWritable) {
+
+    const inputFile: File = files.inputFile as File;
+
+    request.body.inputFile = {
+        size: inputFile.size,
+        originalFilename: inputFile.originalFilename,
+        mimetype: inputFile.mimetype,
+        content: fileUploadWritable.getBuffer()
+    };
+    request.body.subFolder = fields.subFolder as string;
+    request.body.description = fields.description as string;
+}

--- a/src/lsrs/web/utility/middleware.ts
+++ b/src/lsrs/web/utility/middleware.ts
@@ -1,7 +1,5 @@
 import {NextFunction, Request, Response} from "express";
 import {InsufficientScopeError, InvalidTokenError, UnauthorizedError} from "express-oauth2-jwt-bearer";
-import formidable, {File, Part} from "formidable";
-import {Writable} from "stream";
 import {v4 as UUID} from "uuid";
 import {
     ConflictingResourceError,
@@ -47,87 +45,6 @@ export const errorHandlerMiddleware = (error: Error, request: Request, response:
         .status(errorStatusMap.get(errorType) ?? HttpStatus.INTERNAL_SERVER_ERROR)
         .json(errorMessage);
 };
-
-
-/**
- * Writable implementation for file uploads, collecting the received chunks into array, which can be converted into a buffer.
- */
-class FileUploadWritable extends Writable {
-
-    private readonly chunks: any[] = [];
-
-    _write(chunk: any, encoding: BufferEncoding, callback: (error?: (Error | null)) => void) {
-        this.chunks.push(chunk);
-        callback();
-    }
-
-    /**
-     * Returns the collected chunks as concatenated buffer.
-     */
-    getBuffer(): Buffer {
-        return Buffer.concat(this.chunks);
-    }
-}
-
-/**
- * File upload handler middleware for Express using Formidable form parser.
- * Parses the file upload form and collects the file chunks into a FileUploadWritable object. When parsing is done,
- * the collected chunks are converted to a Buffer and finally the file contents and the metadata provided with the
- * uploaded file are passed forward on the chain in the standard Express request object (under the original form field
- * names, inputFile, subFolder and description). Any error that happening while parsing the form triggers a rejection,
- * while success resolved the wrapping Promise object.
- *
- * @param request Express Request object
- * @param response Express Response object
- * @param next Express next function
- */
-export const formidableUploadMiddleware = async (request: Request, response: Response, next: NextFunction) => {
-
-    await new Promise<void>((resolve, _) => {
-
-        const fileUploadWritable = new FileUploadWritable();
-        const form = formidable({
-            fileWriteStreamHandler: () => fileUploadWritable,
-        });
-
-        // The code below aims to mitigate a known issue with how Formidable is handling text/plain form-data fields
-        // https://github.com/node-formidable/formidable/issues/875
-        form.onPart = (part: Part) => {
-            // @ts-ignore
-            if (part.mimetype && !part.headers["content-disposition"]?.match(/filename="/)) {
-                // @ts-ignore
-                delete part.mimetype;
-            }
-
-            form._handlePart(part);
-        };
-
-        form.parse(request, (error, fields, files) => {
-
-            if (error) {
-                response
-                    .status(HttpStatus.BAD_REQUEST)
-                    .json({message: error.message ?? "Invalid input file"});
-            } else {
-
-                const inputFile: File = files.inputFile as File;
-
-                request.body.inputFile = {
-                    size: inputFile.size,
-                    originalFilename: inputFile.originalFilename,
-                    mimetype: inputFile.mimetype,
-                    content: fileUploadWritable.getBuffer()
-                };
-                request.body.subFolder = fields.subFolder as string;
-                request.body.description = fields.description as string;
-            }
-
-            resolve();
-        });
-    });
-
-    next();
-}
 
 /**
  * Creates a request tracking middleware for Express. Allows TSLog logging library to include a shared request ID

--- a/test/lsrs/web/utility/formidable-support.test.ts
+++ b/test/lsrs/web/utility/formidable-support.test.ts
@@ -1,0 +1,90 @@
+import {Request, Response} from "express";
+import {IncomingForm} from "formidable";
+import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import {GenericError} from "../../../../src/lsrs/core/error/error-types";
+import {HttpStatus} from "../../../../src/lsrs/web/model/common";
+import {formidableUploadMiddleware} from "../../../../src/lsrs/web/utility/formidable-support";
+
+describe("Unit tests for Express middleware functions", () => {
+
+    let requestStub: Request;
+    let responseStub: SinonStubbedInstance<Response>;
+    let parseStub: SinonStub;
+
+    beforeEach(() => {
+        requestStub = {body: {}} as unknown as Request;
+        responseStub = sinon.createStubInstance(ResponseStub) as unknown as SinonStubbedInstance<Response>;
+        responseStub.status.returns(responseStub);
+    });
+
+    describe("Test scenarios for #formidableUploadMiddleware", () => {
+
+        afterEach(() => {
+            parseStub.restore();
+        });
+
+        it("should parse file upload form and pass fields to Express Request object", async () => {
+
+            // given
+            const fields = {
+                subFolder: "sub1",
+                description: "file description"
+            };
+            const files = {
+                inputFile: {
+                    size: 10,
+                    originalFilename: "original_filename.jpg",
+                    mimetype: "image/jpg"
+                }
+            };
+
+            parseStub = sinon.stub(IncomingForm.prototype, "parse").callsArgWith(1, null, fields, files);
+            const nextFake = sinon.fake();
+
+            // when
+            await formidableUploadMiddleware(requestStub, responseStub, nextFake);
+
+            // then
+            expect(requestStub.body.inputFile).not.toBeNull();
+            expect(requestStub.body.inputFile.size).toBe(files.inputFile.size);
+            expect(requestStub.body.inputFile.originalFilename).toBe(files.inputFile.originalFilename);
+            expect(requestStub.body.inputFile.mimetype).toBe(files.inputFile.mimetype);
+            expect(requestStub.body.inputFile.content).not.toBeNull();
+            expect(requestStub.body.subFolder).toBe(fields.subFolder);
+            expect(requestStub.body.description).toBe(fields.description);
+
+            sinon.assert.called(nextFake);
+        });
+
+        it("should reject parsing on error", async () => {
+
+            // given
+            parseStub = sinon.stub(IncomingForm.prototype, "parse").callsArgWith(1, new GenericError("something went wrong"), null, null);
+
+            // when
+            await formidableUploadMiddleware(requestStub, responseStub, () => {});
+
+            // then
+            sinon.assert.calledWith(responseStub.json, {message: "something went wrong"});
+            sinon.assert.calledWith(responseStub.status, HttpStatus.BAD_REQUEST);
+        });
+
+        it("should reject parsing on error (string passed as error)", async () => {
+
+            // given
+            parseStub = sinon.stub(IncomingForm.prototype, "parse").callsArgWith(1, "something went wrong", null, null);
+
+            // when
+            await formidableUploadMiddleware(requestStub, responseStub, () => {});
+
+            // then
+            sinon.assert.calledWith(responseStub.json, {message: "Invalid input file"});
+            sinon.assert.calledWith(responseStub.status, HttpStatus.BAD_REQUEST);
+        });
+    });
+});
+
+class ResponseStub {
+    status(status: number): any {}
+    json(body: any): any{}
+}

--- a/test/lsrs/web/utility/middleware.test.ts
+++ b/test/lsrs/web/utility/middleware.test.ts
@@ -111,11 +111,24 @@ describe("Unit tests for Express middleware functions", () => {
             parseStub = sinon.stub(IncomingForm.prototype, "parse").callsArgWith(1, new GenericError("something went wrong"), null, null);
 
             // when
-            const failingCall = async () => await formidableUploadMiddleware(requestStub, responseStub, () => {});
+            await formidableUploadMiddleware(requestStub, responseStub, () => {});
 
             // then
-            // exception expected
-            await expect(failingCall).rejects.toThrow(GenericError);
+            sinon.assert.calledWith(responseStub.json, {message: "something went wrong"});
+            sinon.assert.calledWith(responseStub.status, HttpStatus.BAD_REQUEST);
+        });
+
+        it("should reject parsing on error (string passed as error)", async () => {
+
+            // given
+            parseStub = sinon.stub(IncomingForm.prototype, "parse").callsArgWith(1, "something went wrong", null, null);
+
+            // when
+            await formidableUploadMiddleware(requestStub, responseStub, () => {});
+
+            // then
+            sinon.assert.calledWith(responseStub.json, {message: "Invalid input file"});
+            sinon.assert.calledWith(responseStub.status, HttpStatus.BAD_REQUEST);
         });
     });
 


### PR DESCRIPTION
 - Applied suggested workaround on Formidable middleware
 - Fixed error response on file upload
 - Refactored Formidable middleware and moved into separate module
 - Bumped application version to 0.8.3-dev