### PR TITLE
LFLT-529 Migrate acceptance tests related to file handling to LSRS

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -11,7 +11,7 @@ lsrs:
   storage:
     upload-path: /tmp/storage
     max-age-in-days: 365
-    permission: "0744"
+    permission: "0777"
     acceptors:
       - accepted-as: image
         group-root-directory: images

--- a/test/lsrs/core/config/configuration-provider.test.ts
+++ b/test/lsrs/core/config/configuration-provider.test.ts
@@ -49,7 +49,7 @@ describe("Unit tests for ConfigurationProvider", () => {
             // then
             expect(result).not.toBeNull();
             expect(result.uploadPath).toBe("/tmp/storage");
-            expect(result.permission).toBe("0744");
+            expect(result.permission).toBe("0777");
             expect(result.maxAgeInDays).toBe(365);
 
             expect(result.acceptors.length).toBe(2);


### PR DESCRIPTION
 - Changed storage permission to 777 for test execution